### PR TITLE
Adopt Fence v0.8.7 in audit mode

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -12,18 +12,12 @@ permissions:
 jobs:
   acceptance:
     name: acceptance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - name: harden runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # pin@v2.19.3
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            release-assets.githubusercontent.com:443
-          disable-sudo-and-containers: true
+          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,18 +12,12 @@ permissions:
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - name: harden runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # pin@v2.19.3
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            release-assets.githubusercontent.com:443
-          disable-sudo-and-containers: true
+          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,18 +12,12 @@ permissions:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - name: harden runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # pin@v2.19.3
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            release-assets.githubusercontent.com:443
-          disable-sudo-and-containers: true
+          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6

--- a/script/test
+++ b/script/test
@@ -104,7 +104,9 @@ workflow_paths.each do |path|
       unless fence["uses"] == "openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a"
         failures << "#{relative}:#{job_name} must run Fence v0.8.7 as the first step"
       end
-      failures << "#{relative}:#{job_name} Fence must use audit mode" unless fence.fetch("with", {})["mode"] == "audit"
+      unless fence.fetch("with", {}).fetch("mode", "block") == "block"
+        failures << "#{relative}:#{job_name} Fence must enforce egress"
+      end
     end
 
     steps.each do |step|

--- a/script/test
+++ b/script/test
@@ -97,14 +97,14 @@ workflow_paths.each do |path|
   jobs.each do |job_name, job|
     steps = Array(job.fetch("steps", []))
     if sealed_workflows.include?(workflow_name)
-      harden = steps.first || {}
-      unless harden.fetch("uses", "").start_with?("step-security/harden-runner@")
-        failures << "#{relative}:#{job_name} must run harden-runner as the first step"
+      fence = steps.first || {}
+      unless job["runs-on"] == "ubuntu-24.04"
+        failures << "#{relative}:#{job_name} must run on ubuntu-24.04"
       end
-      harden_with = harden.fetch("with", {})
-      failures << "#{relative}:#{job_name} harden-runner must use egress-policy: block" unless harden_with["egress-policy"] == "block"
-      failures << "#{relative}:#{job_name} harden-runner must disable telemetry" unless harden_with["disable-telemetry"] == true
-      failures << "#{relative}:#{job_name} harden-runner must disable sudo and containers" unless harden_with["disable-sudo-and-containers"] == true
+      unless fence["uses"] == "openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a"
+        failures << "#{relative}:#{job_name} must run Fence v0.8.7 as the first step"
+      end
+      failures << "#{relative}:#{job_name} Fence must use audit mode" unless fence.fetch("with", {})["mode"] == "audit"
     end
 
     steps.each do |step|


### PR DESCRIPTION
## Summary

Replaces StepSecurity Harden Runner with the immutable Fence v0.8.7 Action in all three Ubuntu 24.04 jobs. Audit evidence showed no custom destinations, so all three jobs now run Fence in enforcement mode using only the default GitHub compatibility profile. The workflow security assertions are updated for the new hardener.