### PR TITLE
Restore ubuntu-latest runners

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   acceptance:
     name: acceptance
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7

--- a/script/test
+++ b/script/test
@@ -98,8 +98,8 @@ workflow_paths.each do |path|
     steps = Array(job.fetch("steps", []))
     if sealed_workflows.include?(workflow_name)
       fence = steps.first || {}
-      unless job["runs-on"] == "ubuntu-24.04"
-        failures << "#{relative}:#{job_name} must run on ubuntu-24.04"
+      unless job["runs-on"] == "ubuntu-latest"
+        failures << "#{relative}:#{job_name} must run on ubuntu-latest"
       end
       unless fence["uses"] == "openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a"
         failures << "#{relative}:#{job_name} must run Fence v0.8.7 as the first step"


### PR DESCRIPTION
Restores the Fence-covered Linux jobs from the explicit `ubuntu-24.04` label to `ubuntu-latest`. Fence pins, modes, allowlists, permissions, and job structure remain unchanged; matching workflow assertions are updated where present.